### PR TITLE
[PATCH] libgpiod_1.2: add dependency on python when building python bindings

### DIFF
--- a/meta-oe/recipes-support/libgpiod/libgpiod_1.2.bb
+++ b/meta-oe/recipes-support/libgpiod/libgpiod_1.2.bb
@@ -7,7 +7,7 @@ SRC_URI[sha256sum] = "b6b9079c933f7c8524815437937dda6b795a16141bca202a9eec70ba58
 
 PACKAGECONFIG[cxx] = "--enable-bindings-cxx,--disable-bindings-cxx"
 
-PACKAGECONFIG[python3] = "--enable-bindings-python,--disable-bindings-python,"
+PACKAGECONFIG[python3] = "--enable-bindings-python,--disable-bindings-python,python3"
 inherit ${@bb.utils.contains('PACKAGECONFIG', 'python3', 'python3native', '', d)}
 
 PACKAGES =+ "${PN}-python"


### PR DESCRIPTION
Commit ab54dd75 "libgpiod: Rrecommend python3 only for PN-python package" also removes the build dependency
on python3 however this results in fatal error: Python.h: No such file or directory #include <Python.h>

Signed-off-by: Ferry Toth <ftoth@exalondelft.nl>